### PR TITLE
Remove grpc feature from client and update README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,7 @@ system/server.xml
 include::finish/system/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
+Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute to specify the remote gRPC service's endpoint that clients should connect to for communication. For simplicity in this guide, the `target` attribute is set to a wildcard (`*`), accepting any endpoint. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
 
 Next, implement the corresponding REST endpoint in the `query` service.
 
@@ -286,7 +286,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Specify the [hotspot=grpcClientConfig file=3]`grpcClient` element and configure it with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), accepting any IP address. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), accepting any IP address. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/README.adoc
+++ b/README.adoc
@@ -286,7 +286,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to propagate cookies. This configuration applies universally to all gRPC client calls that get made, as indicated by the wildcard (`*`) in the `host` attribute. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to propagate cookies. This configuration applies universally to all gRPC client calls, as indicated by the wildcard (`*`) in the `host` attribute. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/README.adoc
+++ b/README.adoc
@@ -286,7 +286,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to send security tokens via cookies. This configuration applies universally to all gRPC client calls that get made, as indicated by the wildcard (`*`) in the `host` attribute. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to propagate cookies. This configuration applies universally to all gRPC client calls that get made, as indicated by the wildcard (`*`) in the `host` attribute. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/README.adoc
+++ b/README.adoc
@@ -286,7 +286,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `maxInboundMessageSize` attribute to restrict inbound messages to 1024 bytes. This configuration applies universally to all gRPC client calls that get made, as indicated by the wildcard (`*`) in the `host` attribute. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to send security tokens via cookies. This configuration applies universally to all gRPC client calls that get made, as indicated by the wildcard (`*`) in the `host` attribute. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,7 @@ system/server.xml
 include::finish/system/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute. If you want to learn more about configuration for the `grpc` feature, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
+Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
 
 Next, implement the corresponding REST endpoint in the `query` service.
 
@@ -286,7 +286,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Specify the [hotspot=grpcClientConfig file=3]`grpcClient` element and configure it with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), accepting any IP address. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` feature configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Specify the [hotspot=grpcClientConfig file=3]`grpcClient` element and configure it with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), accepting any IP address. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/README.adoc
+++ b/README.adoc
@@ -257,8 +257,6 @@ include::finish/system/src/main/liberty/config/server.xml[]
 
 Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute to specify the remote gRPC service's endpoint or service name that clients should connect to for communication. For simplicity in this guide, the `target` attribute is set to a wildcard (`*`), indicating that the configuration is relevant for any target. However, this doesn't guarantee that every configuration setting will be applied to every target. In practical scenarios, it's recommended to specify a particular endpoint or service name. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
 
-Configure the [hotspot=grpcConfig file=1]grpc element with the target attribute to specify the remote gRPC service's endpoint 
-
 Next, implement the corresponding REST endpoint in the `query` service.
 
 // Create PropertiesResource

--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,7 @@ system/server.xml
 include::finish/system/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute to specify the remote gRPC service's endpoint or service name that clients should connect to for communication. For simplicity in this guide, the `target` attribute is set to a wildcard (`*`), indicating that the configuration is relevant for any target. However, this doesn't guarantee that every configuration setting will be applied to every target. In practical scenarios, it's recommended to specify a particular endpoint or service name. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
+Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute. For simplicity in this guide, the `target` attribute is set to a wildcard (`*`), indicating that the attached configuration is universally applicable to all matching gRPC services. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
 
 Next, implement the corresponding REST endpoint in the `query` service.
 

--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,7 @@ system/server.xml
 include::finish/system/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute. For simplicity in this guide, the `target` attribute is set to a wildcard (`*`), indicating that the attached configuration is universally applicable to all matching gRPC services. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
+Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `maxInboundMessageSize` attribute to restrict inbound messages to 1024 bytes. This configuration applies universally to all gRPC services running on the server, as indicated by the wildcard (`*`) in the `target` attribute. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
 
 Next, implement the corresponding REST endpoint in the `query` service.
 
@@ -286,7 +286,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), applying the configuration to all remote services. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `maxInboundMessageSize` attribute to restrict inbound messages to 1024 bytes. This configuration applies universally to all gRPC client calls that get made, as indicated by the wildcard (`*`) in the `host` attribute. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,9 @@ system/server.xml
 include::finish/system/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute to specify the remote gRPC service's endpoint that clients should connect to for communication. For simplicity in this guide, the `target` attribute is set to a wildcard (`*`), accepting any endpoint. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
+Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute to specify the remote gRPC service's endpoint or service name that clients should connect to for communication. For simplicity in this guide, the `target` attribute is set to a wildcard (`*`), indicating that the configuration is relevant for any target. However, this doesn't guarantee that every configuration setting will be applied to every target. In practical scenarios, it's recommended to specify a particular endpoint or service name. If you want to learn more about configuration for the `grpc` element, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
+
+Configure the [hotspot=grpcConfig file=1]grpc element with the target attribute to specify the remote gRPC service's endpoint 
 
 Next, implement the corresponding REST endpoint in the `query` service.
 
@@ -286,7 +288,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), accepting any IP address. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` element with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), applying the configuration to all remote services. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` element configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,7 @@ system/server.xml
 include::finish/system/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` feature with the `target` attribute. If you want to learn more about configuration for the `grpc` feature, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
+Add the [hotspot=grpc file=1]`grpc` feature to the Liberty `server.xml` configuration file. This feature enables applications running on Liberty to provide gRPC services. Configure the [hotspot=grpcConfig file=1]`grpc` element with the `target` attribute. If you want to learn more about configuration for the `grpc` feature, see the https://openliberty.io/docs/latest/reference/config/grpc.html[GRPC Server Properties^].
 
 Next, implement the corresponding REST endpoint in the `query` service.
 
@@ -286,7 +286,7 @@ query/server.xml
 include::finish/query/src/main/liberty/config/server.xml[]
 ----
 
-Add the [hotspot=grpc file=3]`grpc` and [hotspot=grpcClient file=3]`grpcClient` features to the Liberty `server.xml` configuration file for the `query` service. These two features enable gRPC server and client support on Liberty respectively. Configure the [hotspot=grpcClientConfig file=3]`grpcClient` feature with the `headersToPropagate` and `target` attributes. If you want to learn more about `grpcClient` feature configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
+Add the [hotspot=grpcClient file=3]`grpcClient` feature to the Liberty `server.xml` configuration file for the `query` service. This feature enables gRPC client support on Liberty. Specify the [hotspot=grpcClientConfig file=3]`grpcClient` element and configure it with the `headersToPropagate` attribute to send security tokens via cookies, and the `host` attribute to specify the remote gRPC service's hostname. For simplicity in this guide, the `host` attribute is set to a wildcard (`*`), accepting any IP address. However, in a production environment, it's recommended to specify the exact hostname. If you want to learn more about `grpcClient` feature configuration, see the https://openliberty.io/docs/latest/reference/config/grpcClient.html[GRPC Client Properties^].
 
 Because you are running the `system` and `query` services in dev mode, the changes that you made are automatically picked up. You’re now ready to check out your application in your browser.
 

--- a/finish/query/src/main/liberty/config/server.xml
+++ b/finish/query/src/main/liberty/config/server.xml
@@ -21,7 +21,7 @@
                   host="*"/>
 
     <!-- tag::grpcClientConfig[] -->
-    <grpcClient host="*" maxInboundMessageSize="1024"/>
+    <grpcClient host="*" headersToPropagate="Cookie"/>
     <!-- end::grpcClientConfig[] -->
 
     <applicationManager autoExpand="true"/>

--- a/finish/query/src/main/liberty/config/server.xml
+++ b/finish/query/src/main/liberty/config/server.xml
@@ -21,11 +21,7 @@
                   host="*"/>
 
     <!-- tag::grpcClientConfig[] -->
-    <!-- Due to host="*", this configuration will be applied to every gRPC client call
-         that gets made. This configuration registers a ClientInterceptor, and it directs
-         Cookie headers to get forwarded with any outbound RPC calls, in this case, that
-         enables authorization propagation. -->
-    <grpcClient headersToPropagate="Cookie" host="*"/>
+    <grpcClient host="*" maxInboundMessageSize="1024"/>
     <!-- end::grpcClientConfig[] -->
 
     <applicationManager autoExpand="true"/>

--- a/finish/query/src/main/liberty/config/server.xml
+++ b/finish/query/src/main/liberty/config/server.xml
@@ -7,9 +7,6 @@
         <feature>jsonb-3.0</feature>
         <feature>cdi-4.0</feature>
         <feature>mpConfig-3.0</feature>
-        <!-- tag::grpc[] -->
-        <feature>grpc-1.0</feature>
-        <!-- end::grpc[] -->
         <!-- tag::grpcClient[] -->
         <feature>grpcClient-1.0</feature>
         <!-- end::grpcClient[] -->

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -9,9 +9,7 @@
     </featureManager>
 
     <!-- tag::grpcConfig[] -->
-    <!-- Due to target="*", this configuration will be applied to every gRPC service 
-         running on the server. This configuration registers a ServerInterceptor -->
-    <grpc target="*"/>
+    <grpc target="*" maxInboundMessageSize="1024"/>
     <!-- end::grpcConfig[] -->
 
     <applicationManager autoExpand="true"/>


### PR DESCRIPTION
- Addressed https://github.com/OpenLiberty/guide-grpc-intro/issues/58
  - Removed the `grpc` feature used for server-side configurations from the `query` microservice, which represents a gRPC client, for clarity and to avoids potential confusion.
  - Updated the README to mirror the code changes, correct references based on feedback, and provide clearer descriptions.
